### PR TITLE
Added some functionality to upcode dart:format command so that it works on Windows without erroring out due to command length

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.10.13
+
+Added a flag to upcode dart:format so the command could run on Windows without command line length errors.
+
 ## 0.10.12
 
 Only replace the first iteration of version. 

--- a/lib/src/commands/dart/format.dart
+++ b/lib/src/commands/dart/format.dart
@@ -44,7 +44,7 @@ class DartFormatCommand extends UpcodeCommand {
           .where(fileFilter)
           .toList();
 
-      final List<List<String>> chunks = _chunkList(files, 50); // Adjust the chunk size as needed
+      final List<List<String>> chunks = _chunkList(files, 100); // Adjust the chunk size as needed
 
       for (final List<String> chunk in chunks) {
         await execute(

--- a/lib/src/commands/dart/format.dart
+++ b/lib/src/commands/dart/format.dart
@@ -1,3 +1,7 @@
+// File created by
+// Lung Razvan <long1eu>
+// on 09/05/2020
+
 import 'dart:async';
 import 'dart:io';
 

--- a/lib/src/commands/dart/format.dart
+++ b/lib/src/commands/dart/format.dart
@@ -44,7 +44,7 @@ class DartFormatCommand extends UpcodeCommand {
           .where(fileFilter)
           .toList();
 
-      final List<List<String>> chunks = _chunkList(files, 200); // Adjust the chunk size as needed
+      final List<List<String>> chunks = _chunkList(files, 50); // Adjust the chunk size as needed
 
       for (final List<String> chunk in chunks) {
         await execute(

--- a/lib/src/commands/dart/format.dart
+++ b/lib/src/commands/dart/format.dart
@@ -37,7 +37,11 @@ class DartFormatCommand extends UpcodeCommand {
   @override
   FutureOr<dynamic> run() async {
     final bool modify = argResults!['modify'] ?? false;
-    final bool chunks = argResults!['chunks'] ?? false;
+    bool chunks = argResults!['chunks'] ?? false;
+
+    if (Platform.isWindows) {
+      chunks = true;
+    }
 
     List<String> modules;
     if (argResults!.wasParsed('module')) {
@@ -81,7 +85,7 @@ class DartFormatCommand extends UpcodeCommand {
   }
 
   List<List<String>> _chunkList(List<String> list, int chunkSize) {
-    final List<List<String>> chunks = [];
+    final List<List<String>> chunks = <List<String>>[];
     for (int i = 0; i < list.length; i += chunkSize) {
       chunks.add(list.sublist(i, i + chunkSize > list.length ? list.length : i + chunkSize));
     }

--- a/lib/src/commands/dart/format.dart
+++ b/lib/src/commands/dart/format.dart
@@ -1,7 +1,3 @@
-// File created by
-// Lung Razvan <long1eu>
-// on 09/05/2020
-
 import 'dart:async';
 import 'dart:io';
 
@@ -15,7 +11,7 @@ class DartFormatCommand extends UpcodeCommand {
         'modify',
         defaultsTo: false,
         help:
-            'If false it will only check if there are changes that need to be done and exists with non 0 code if so. If true it will format the code.',
+        'If false it will only check if there are changes that need to be done and exists with non 0 code if so. If true it will format the code.',
       )
       ..addMultiOption(
         'module',
@@ -48,14 +44,26 @@ class DartFormatCommand extends UpcodeCommand {
           .where(fileFilter)
           .toList();
 
-      await execute(
-        () => runCommand(
-          'dart',
-          <String>['format', '-l', '120', if (!modify) '--set-exit-if-changed', ...files],
-          workingDirectory: module,
-        ),
-        description,
-      );
+      final List<List<String>> chunks = _chunkList(files, 200); // Adjust the chunk size as needed
+
+      for (final List<String> chunk in chunks) {
+        await execute(
+              () => runCommand(
+            'dart',
+            <String>['format', '-l', '120', if (!modify) '--set-exit-if-changed', ...chunk],
+            workingDirectory: module,
+          ),
+          description,
+        );
+      }
     }
+  }
+
+  List<List<String>> _chunkList(List<String> list, int chunkSize) {
+    final List<List<String>> chunks = [];
+    for (int i = 0; i < list.length; i += chunkSize) {
+      chunks.add(list.sublist(i, i + chunkSize > list.length ? list.length : i + chunkSize));
+    }
+    return chunks;
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: upcode_ci
 description: A collection of tools used by Upcode team
-version: 0.10.12+1
+version: 0.10.13
 repository: https://github.com/long1eu/upcode_ci
 executables:
   upcode:


### PR DESCRIPTION
upcode dart:format didn't work on windows because the generated list of files was too long for the command line to run, so I added a flag `chunks` to the command so that, if passed, it broke the list of files into chunks of 100 and ran each of those commands sequentially instead. I tested it on my computer and it works, so I thought I'd create a PR so it isn't a change specific to my computer! Please let me know if I need to change anything.