### PR TITLE
Route flutter/dart through fvm for fvm-configured projects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.10.19
+
+Route `flutter` and `dart` invocations through `fvm` when the target project is
+fvm-configured (has a `.fvmrc` file or `.fvm/` directory) and the `fvm` binary
+is on `PATH`. Falls back to the bare executable otherwise.
+
 ## 0.10.18
 
 Add `--path` option to `upcode fad upload` to override the default apk/ipa

--- a/docs/superpowers/specs/2026-05-16-fvm-flutter-dart-routing-design.md
+++ b/docs/superpowers/specs/2026-05-16-fvm-flutter-dart-routing-design.md
@@ -1,0 +1,96 @@
+# Route `flutter` / `dart` through fvm when a project is fvm-configured
+
+**Date:** 2026-05-16
+**Status:** Approved
+
+## Problem
+
+The `upcode` CLI invokes the `flutter` and `dart` executables directly. When a
+target Flutter project pins its SDK with [fvm](https://fvm.app), running the
+bare `flutter`/`dart` from `PATH` uses the global SDK instead of the pinned one,
+which can produce inconsistent build, analysis, and codegen results.
+
+`upcode` should run `fvm flutter` / `fvm dart` when the project it operates on
+is fvm-configured.
+
+## Goal
+
+When a command's working directory belongs to an fvm-configured project and the
+`fvm` binary is available, route `flutter` and `dart` invocations through `fvm`.
+Otherwise, behave exactly as today.
+
+## Affected call sites
+
+All go through `runCommand` in `lib/src/commands/command.dart:380`:
+
+- `flutter` — `flutter:test`, `flutter:analyze`, `flutter:buildrunner`
+- `dart` — `flutter:i18n`, `flutter:format`, `flutter:version`, `dart:analyze`,
+  `dart:format`
+
+`fastlane` and other executables are out of scope.
+
+## Design
+
+### Approach
+
+Centralize the resolution in `runCommand`. It already receives both the
+`executable` name and the `workingDirectory`, so it is the single chokepoint
+that cannot miss a call site. No changes are needed in the individual command
+files.
+
+### Detection
+
+Two pure checks, both cached:
+
+- **`_isFvmConfigured(dir)`** — walk up from `dir` to the filesystem root;
+  return `true` if any ancestor contains a `.fvmrc` file or a `.fvm/`
+  directory. Walking up handles both layouts: the module *is* the Flutter
+  project root, or it is a sub-package inside an fvm-configured repo
+  (`modules` / `generatedModules` may point at separate sub-packages).
+  Results are cached per directory to avoid repeated filesystem walks.
+
+- **`_fvmOnPath()`** — return whether the `fvm` binary is resolvable on
+  `PATH`. The boolean is cached for the process lifetime.
+
+### Resolution
+
+In `runCommand`, before `Process.start`:
+
+```
+if executable in {flutter, dart}
+   and _fvmOnPath()
+   and _isFvmConfigured(workingDirectory):
+       arguments  = [executable, ...arguments]
+       executable = 'fvm'
+```
+
+Otherwise `executable` and `arguments` are unchanged.
+
+### Fallback behavior
+
+If a project is fvm-configured but the `fvm` binary is not on `PATH`, fall back
+to the bare `flutter`/`dart` executable. This matches the intent: use fvm *when
+available*, never hard-fail because of it.
+
+### Observability
+
+The existing `RUNNING …` / `ELAPSED TIME` log lines derive their description
+from `executable` + `arguments`. After resolution they naturally print
+`fvm flutter pub get`, making the fvm routing visible without extra logging.
+
+## Testing
+
+The repository currently has no `test/` directory.
+
+- `_isFvmConfigured` is pure and walk-based — add focused unit tests under a new
+  `test/` directory covering: an fvm-configured project root, a sub-package
+  nested inside an fvm-configured repo, and an unconfigured directory tree.
+  Cover both the `.fvmrc` file and the `.fvm/` directory forms.
+- `runCommand` spawns real processes, so it is out of scope for unit tests;
+  verification of the end-to-end routing is manual.
+
+## Out of scope
+
+- Routing `fastlane` or any executable other than `flutter`/`dart`.
+- An opt-out flag or upcode config setting — detection is automatic.
+- Installing or managing fvm itself.

--- a/lib/src/commands/command.dart
+++ b/lib/src/commands/command.dart
@@ -377,6 +377,53 @@ bool fileFilter(String it) =>
     !it.endsWith('.config.dart') &&
     !it.endsWith('.test_coverage.dart');
 
+bool? _fvmOnPathCache;
+
+/// Whether the `fvm` binary is resolvable on `PATH`.
+///
+/// The result never changes during a process run, so it is cached.
+bool fvmOnPath() => _fvmOnPathCache ??= _detectFvmOnPath();
+
+bool _detectFvmOnPath() {
+  final String? pathVar = Platform.environment['PATH'];
+  if (pathVar == null) {
+    return false;
+  }
+  final List<String> names =
+      Platform.isWindows ? <String>['fvm.bat', 'fvm.cmd', 'fvm.exe', 'fvm'] : <String>['fvm'];
+  for (final String entry in pathVar.split(Platform.isWindows ? ';' : ':')) {
+    if (entry.isEmpty) {
+      continue;
+    }
+    for (final String name in names) {
+      if (File(path.join(entry, name)).existsSync()) {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
+/// Whether [dir] (or any ancestor) belongs to an fvm-configured project.
+///
+/// A project is fvm-configured when it contains a `.fvmrc` file or a `.fvm/`
+/// directory. The check walks up to the filesystem root so it also matches a
+/// sub-package nested inside an fvm-configured repository.
+bool isFvmConfigured(String dir) {
+  String current = path.absolute(dir);
+  while (true) {
+    if (File(path.join(current, '.fvmrc')).existsSync() ||
+        Directory(path.join(current, '.fvm')).existsSync()) {
+      return true;
+    }
+    final String parent = path.dirname(current);
+    if (parent == current) {
+      return false;
+    }
+    current = parent;
+  }
+}
+
 Future<void> runCommand(
   String executable,
   List<String> arguments, {
@@ -394,6 +441,13 @@ Future<void> runCommand(
       (outputMode == OutputMode.capture) == (output != null),
       'The output parameter must be non-null with and only with '
       'OutputMode.capture');
+
+  if ((executable == 'flutter' || executable == 'dart') &&
+      fvmOnPath() &&
+      isFvmConfigured(workingDirectory)) {
+    arguments = <String>[executable, ...arguments];
+    executable = 'fvm';
+  }
 
   final String commandDescription = '${path.relative(executable, from: workingDirectory)} ${arguments.join(' ')}';
   final String relativeWorkingDir = path.relative(workingDirectory);

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: upcode_ci
 description: A collection of tools used by Upcode team
-version: 0.10.18
+version: 0.10.19
 repository: https://github.com/long1eu/upcode_ci
 executables:
   upcode:
@@ -27,3 +27,5 @@ dependencies:
   collection: ^1.18.0
   grpc: ^3.2.4
   strings: ^2.0.3
+dev_dependencies:
+  test: ^1.31.1

--- a/test/fvm_test.dart
+++ b/test/fvm_test.dart
@@ -1,0 +1,41 @@
+import 'dart:io';
+
+import 'package:path/path.dart';
+import 'package:test/test.dart';
+import 'package:upcode_ci/src/commands/command.dart';
+
+void main() {
+  group('isFvmConfigured', () {
+    late Directory root;
+
+    setUp(() => root = Directory.systemTemp.createTempSync('fvm_test'));
+    tearDown(() => root.deleteSync(recursive: true));
+
+    test('returns true when the directory contains a .fvmrc file', () {
+      File(join(root.path, '.fvmrc')).writeAsStringSync('{"flutter": "3.2.1"}');
+
+      expect(isFvmConfigured(root.path), isTrue);
+    });
+
+    test('returns true when the directory contains a .fvm directory', () {
+      Directory(join(root.path, '.fvm')).createSync();
+
+      expect(isFvmConfigured(root.path), isTrue);
+    });
+
+    test('returns true for a sub-package nested in an fvm-configured repo', () {
+      File(join(root.path, '.fvmrc')).writeAsStringSync('{"flutter": "3.2.1"}');
+      final Directory subPackage = Directory(join(root.path, 'packages', 'app'))
+        ..createSync(recursive: true);
+
+      expect(isFvmConfigured(subPackage.path), isTrue);
+    });
+
+    test('returns false for a directory tree without fvm config', () {
+      final Directory subPackage = Directory(join(root.path, 'packages', 'app'))
+        ..createSync(recursive: true);
+
+      expect(isFvmConfigured(subPackage.path), isFalse);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

`upcode` invokes the `flutter` and `dart` executables directly. When a target project pins its SDK with [fvm](https://fvm.app), the bare executables use the global SDK instead of the pinned one.

`runCommand` now rewrites `flutter`/`dart` invocations to run through `fvm` when the working directory belongs to an fvm-configured project (`.fvmrc` file or `.fvm/` directory, detected by walking up to the filesystem root) and the `fvm` binary is on `PATH`. It falls back to the bare executable otherwise. Centralizing this in `runCommand` covers every flutter/dart call site (`flutter:test`, `flutter:analyze`, `flutter:buildrunner`, `flutter:i18n`, `flutter:format`, `flutter:version`, `dart:analyze`, `dart:format`).

## Changes

- `isFvmConfigured(dir)` and `fvmOnPath()` helpers in `command.dart`; `fvmOnPath()` result is cached for the process.
- Routing block in `runCommand`.
- New `test/fvm_test.dart` covering `isFvmConfigured`: `.fvmrc` file, `.fvm/` directory, nested sub-package, and an unconfigured tree.
- `test` added as a dev dependency; version bumped to 0.10.19.
- Design doc under `docs/superpowers/specs/`.

## Testing

- `dart test` — 4/4 pass.
- `dart analyze` on changed files — no issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)