### PR TITLE
Batch files when formatting on all platforms (0.10.20)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.10.20
+
+Batch files into chunks of 100 when running `dart format` on all platforms.
+Previously the batching applied only on Windows.
+
 ## 0.10.19
 
 Route `flutter` and `dart` invocations through `fvm` when the target project is

--- a/lib/src/commands/dart/format.dart
+++ b/lib/src/commands/dart/format.dart
@@ -49,9 +49,7 @@ class DartFormatCommand extends UpcodeCommand {
           .where(fileFilter)
           .toList();
 
-      final List<List<String>> elements = Platform.isWindows //
-          ? files.slices(100).toList()
-          : <List<String>>[files];
+      final List<List<String>> elements = files.slices(100).toList();
 
       for (final List<String> items in elements) {
         await execute(

--- a/lib/src/commands/flutter/format.dart
+++ b/lib/src/commands/flutter/format.dart
@@ -49,9 +49,7 @@ class FlutterFormatCommand extends UpcodeCommand {
           .where(fileFilter)
           .toList();
 
-      final List<List<String>> elements = Platform.isWindows //
-          ? files.slices(100).toList()
-          : <List<String>>[files];
+      final List<List<String>> elements = files.slices(100).toList();
 
       for (final List<String> items in elements) {
         await execute(

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: upcode_ci
 description: A collection of tools used by Upcode team
-version: 0.10.19
+version: 0.10.20
 repository: https://github.com/long1eu/upcode_ci
 executables:
   upcode:


### PR DESCRIPTION
## Summary

`dart:format` and `flutter:format` sliced files into chunks of 100 only
on Windows. This applies the same batching on every platform, so a large
module file list does not exceed command-line length limits regardless
of OS.

## Changes

- `dart/format.dart`, `flutter/format.dart` — always batch into chunks of 100.
- Version bumped to 0.10.20 with a CHANGELOG entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)