### PR TITLE
Surface flutter:fad deprecation and rename fcm send command class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 0.10.27
+
+Mark `upcode flutter:fad` as deprecated in its `--help` description so the
+existing runtime warning is also visible when listing commands; use
+`upcode fad upload` instead. Rename the `fcm send` command's implementation
+class to `FcmSendCommand` (it was misnamed `DartAnalyzeCommand`) and correct
+the `fcm` group description.
+
 ## 0.10.26
 
 `upcode fad ai-test`: retry the App Testing `createReleaseTest` call with

--- a/lib/src/commands/flutter/firebase_app_distribution_old.dart
+++ b/lib/src/commands/flutter/firebase_app_distribution_old.dart
@@ -49,7 +49,7 @@ class FlutterFirebaseAppDistributionCommand extends UpcodeCommand with Environme
   final String name = 'flutter:fad';
 
   @override
-  final String description = 'Distribute app on Firebase App Distribution';
+  final String description = 'Deprecated: use `fad upload`. Distribute app on Firebase App Distribution.';
 
   @override
   FutureOr<dynamic> run() async {

--- a/lib/src/commands/google/fcm.dart
+++ b/lib/src/commands/google/fcm.dart
@@ -11,18 +11,18 @@ import 'package:upcode_ci/src/commands/command.dart';
 
 class FcmCommand extends UpcodeCommand {
   FcmCommand(Map<String, dynamic> config) : super(config) {
-    addSubcommand(DartAnalyzeCommand(config));
+    addSubcommand(FcmSendCommand(config));
   }
 
   @override
   final String name = 'fcm';
 
   @override
-  final String description = 'Adds or remove environments';
+  final String description = 'Firebase Cloud Messaging operations.';
 }
 
-class DartAnalyzeCommand extends UpcodeCommand {
-  DartAnalyzeCommand(Map<String, dynamic> config) : super(config) {
+class FcmSendCommand extends UpcodeCommand {
+  FcmSendCommand(Map<String, dynamic> config) : super(config) {
     argParser.addOption(
       'message',
       abbr: 'm',

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: upcode_ci
 description: A collection of tools used by Upcode team
-version: 0.10.26
+version: 0.10.27
 repository: https://github.com/long1eu/upcode_ci
 executables:
   upcode:


### PR DESCRIPTION
## Summary

Two small cleanups flagged during the README rewrite.

- **`flutter:fad` deprecation visibility.** The command already prints a runtime warning that it will be removed, but its `--help` description didn't say so. Updated the description to `Deprecated: use \`fad upload\`...` so the deprecation shows when listing commands. The command still works — this only surfaces the existing intent, keeping it removable later.
- **`fcm send` class rename.** The `fcm send` command was implemented by a class named `DartAnalyzeCommand` — a copy-paste leftover unrelated to its behavior. Renamed it to `FcmSendCommand` and fixed the `fcm` group description, which read `Adds or remove environments`.

No behavior changes. Version bumped to 0.10.27.

## Testing

- `dart analyze` on changed files — no issues.
- `dart test` — 4/4 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)