### PR TITLE
fad ai-test: fall back to service account when no Firebase token

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 0.10.29
+
+`upcode fad ai-test`: fall back to the service account for the App Testing
+release-tests API when no Firebase user token is provided. A user token
+(`--token` or `FIREBASE_TOKEN`) is still used when present; without one the
+command now uses the service-account client instead of failing.
+
 ## 0.10.28
 
 Remove the deprecated `upcode flutter:fad` command; use `upcode fad upload`

--- a/lib/src/commands/flutter/firebase_app_distribution.dart
+++ b/lib/src/commands/flutter/firebase_app_distribution.dart
@@ -302,9 +302,9 @@ class FadAiTestCommand extends UpcodeCommand with EnvironmentMixin, ApplicationM
       ..addOption(
         'token',
         abbr: 't',
-        help: 'A Firebase user refresh token (from `firebase login:ci`). Required: the App Testing '
-            'release-tests API only accepts a user identity, not the service account. Falls back to '
-            r'the FIREBASE_TOKEN environment variable.',
+        help: 'A Firebase user refresh token (from `firebase login:ci`) for the App Testing '
+            'release-tests API. Falls back to the FIREBASE_TOKEN environment variable, then to '
+            'the service account when neither is set.',
       )
       ..addMultiOption(
         'device',
@@ -344,9 +344,10 @@ class FadAiTestCommand extends UpcodeCommand with EnvironmentMixin, ApplicationM
     return ClientId(id, secret);
   }
 
-  /// Auto-refreshing client for the user identity (the release-tests API
-  /// rejects the service account). The service-account [googleClient] is still
-  /// used for fetching the app and uploading the release.
+  /// Client used for the App Testing release-tests API. Prefers the user
+  /// identity from `--token`/`FIREBASE_TOKEN`, falling back to the
+  /// service-account [googleClient] (also used for fetching the app and
+  /// uploading the release) when no token is provided.
   late final AutoRefreshingAuthClient _testClient;
 
   AutoRefreshingAuthClient _userClient(String refreshToken) {
@@ -530,14 +531,16 @@ class FadAiTestCommand extends UpcodeCommand with EnvironmentMixin, ApplicationM
 
   @override
   FutureOr<dynamic> run() async {
-    final String? refreshToken = (argResults!['token'] as String?) ?? Platform.environment['FIREBASE_TOKEN'];
-    if (refreshToken == null || refreshToken.isEmpty) {
-      throw StateError('A user token is required (--token or FIREBASE_TOKEN). The App Testing '
-          'release-tests API does not accept the service account. Generate one with `firebase login:ci`.');
-    }
-    _testClient = _userClient(refreshToken);
-
     await initFirebase();
+
+    final String? refreshToken = (argResults!['token'] as String?) ?? Platform.environment['FIREBASE_TOKEN'];
+    if (refreshToken != null && refreshToken.isNotEmpty) {
+      _testClient = _userClient(refreshToken);
+    } else {
+      stdout.writeln('No Firebase user token (--token / FIREBASE_TOKEN); '
+          'using the service account for the App Testing release-tests API.');
+      _testClient = googleClient!;
+    }
 
     final String path = _getPath();
     final String appId = await execute(() async => (await getAndroidApp()).appId!, 'Fetch application id');

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: upcode_ci
 description: A collection of tools used by Upcode team
-version: 0.10.28
+version: 0.10.29
 repository: https://github.com/long1eu/upcode_ci
 executables:
   upcode:


### PR DESCRIPTION
## Summary

`upcode fad ai-test` previously threw if neither `--token` nor `FIREBASE_TOKEN` was set, because the App Testing release-tests API was driven only with a Firebase user identity. This adds a service-account fallback:

- A user token (`--token` / `FIREBASE_TOKEN`) is still preferred and used when present.
- When no token is set, the command now uses the service-account client (`googleClient`) for the release-tests API instead of failing.

`initFirebase()` now runs before client selection so the service-account client is available for the fallback. The `--token` help text and the `_testClient` doc comment were updated to match.

## Note

The original code asserted that the release-tests API rejects the service account. If that's still enforced server-side, the API calls will fail at request time rather than upfront — the token path remains the reliable one. This change makes the service account the no-token fallback as requested.

## Testing

- `dart analyze` on the changed file — no issues.
- `dart test` — 4/4 pass.
- Network behavior (actual release-tests calls under each identity) is manual, consistent with the rest of this command.

🤖 Generated with [Claude Code](https://claude.com/claude-code)